### PR TITLE
Revert "Update changesets/action action to v1.5.3"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish Packages
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        uses: changesets/action@001cd79f0a536e733315164543a727bdf2d70aff # v1.5.1
         with:
           publish: yarn changeset tag
           cwd: ./matrix-neoboard-standalone/


### PR DESCRIPTION
Reverts nordeck/matrix-neoboard-standalone#55

This breaks our CI due to https://github.com/changesets/action/issues/501