### PR TITLE
Use correct tag name to fix publish-release.yml

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,7 @@ name: Release Package
 on:
   push:
     tags:
-      - '*'
+      - 'v*' # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet
 
 jobs:
   build:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,7 @@ name: Release Package
 on:
   push:
     tags:
-      - '@nordeck/matrix-neoboard-standalone@*'
+      - '*'
 
 jobs:
   build:
@@ -37,7 +37,7 @@ jobs:
             org.opencontainers.image.description=A collaborative whiteboard
             org.opencontainers.image.vendor=Nordeck IT + Consulting GmbH
           tags: |
-            type=match,pattern=@nordeck/matrix-neoboard-standalone@(.+),group=1
+            type=semver,pattern={{version}}
 
       - name: Generate Dockerfile
         env:


### PR DESCRIPTION
Update `publish-release.yml` to use a correct tag name. 

Standalone is a single repository and `changeset tag` [creates a tag](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#tag) in the format: v before the version number. Therefore have to update `publish-release.yml`.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
