### PR TITLE
Pin trivy to 0.69.3 / trivy-action to v0.35.0

### DIFF
--- a/.changeset/dry-doors-hide.md
+++ b/.changeset/dry-doors-hide.md
@@ -1,0 +1,6 @@
+---
+'@nordeck/matrix-neoboard-standalone': patch
+---
+
+Pin trivy version to 0.69.3
+Pin trivy-action to v0.35.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{ success() && steps.build_and_push.outputs.digest }}
         env:
           IMAGE_REF: ${{ env.DOCKER_IMAGE }}@${{ steps.build_and_push.outputs.digest }}
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'image'
           scanners: 'license'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Run Trivy to get an SBOM report of the container
         env:
           IMAGE_REF: ${{ env.DOCKER_IMAGE }}@${{ steps.build_and_push.outputs.digest }}
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'image'
           scanners: 'license'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:latest AS scanner
+FROM aquasec/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c AS scanner
 
 # Copy yarn.lock to run SBOM scan
 COPY yarn.lock /tmp


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).

The trivy docker image has been pinned to 0.69.3, and trivy-action has been pinned to v0.35.0.
A vulnerable version of trivy-action has never been run, however several vulnerable docker images have been pulled (in workflow runs [23408133384](https://github.com/nordeck/matrix-neoboard-standalone/actions/runs/23408133384) and [23317345257](https://github.com/nordeck/matrix-neoboard-standalone/actions/runs/23317345257)).
Resulting artifacts should be deleted, and all accessible secrets rotated.