### PR TITLE
perf: cache board SVG previews and lazy-load uncached boards

### DIFF
--- a/src/components/BoardView/BoardView.tsx
+++ b/src/components/BoardView/BoardView.tsx
@@ -38,6 +38,7 @@ import { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { useAppDispatch } from '../../store';
+import { savePreviewSvg } from '../Dashboard/boardPreviewCache.ts';
 import { useSaveOnLeave } from '../LoggedInLayout/useSaveOnLeave.tsx';
 import { useOpenedRoomId } from '../RoomIdProvider';
 import { SnapshotLoadStateDialog } from '../SnapshotLoadStateDialog/SnapshotLoadStateDialog';
@@ -100,9 +101,19 @@ export const BoardView = () => {
     };
 
     return () => {
+      const svgElement = document.querySelector(
+        '[data-guided-tour-target="canvas"] svg',
+      );
+      if (svgElement) {
+        const svgHtml = svgElement.outerHTML.replace(
+          /\s(?:href|xlink:href)="blob:[^"]*"/g,
+          '',
+        );
+        void savePreviewSvg(roomId, svgHtml);
+      }
       handleClear();
     };
-  }, [whiteboardManager, persist, clearWhiteboard]);
+  }, [whiteboardManager, persist, clearWhiteboard, roomId]);
 
   return (
     <>

--- a/src/components/Dashboard/BoardPreview.tsx
+++ b/src/components/Dashboard/BoardPreview.tsx
@@ -33,30 +33,64 @@ import React, { useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import { useLoggedIn } from '../../state';
 import { RootState } from '../../store';
+import { getPreviewSvg } from './boardPreviewCache.ts';
 import { NoBoardPreview } from './NoBoardPreview.tsx';
+import { useLazyLoad } from './useLazyLoad.ts';
 
 interface BoardPreviewProps {
   whiteboard: StateEvent<Whiteboard>;
 }
 
 export const BoardPreview: React.FC<BoardPreviewProps> = ({ whiteboard }) => {
+  const [cachedSvg, setCachedSvg] = useState<string | null | 'loading'>(
+    'loading',
+  );
+
+  useEffect(() => {
+    getPreviewSvg(whiteboard.room_id)
+      .then(setCachedSvg)
+      .catch(() => setCachedSvg(null));
+  }, [whiteboard.room_id]);
+
+  if (cachedSvg === 'loading') return <SlideSkeleton />;
+
+  if (cachedSvg !== null) {
+    return (
+      <img
+        src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(cachedSvg)}`}
+        style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+        alt=""
+      />
+    );
+  }
+
+  return <LazyFullBoardPreview whiteboard={whiteboard} />;
+};
+
+function LazyFullBoardPreview({
+  whiteboard,
+}: {
+  whiteboard: StateEvent<Whiteboard>;
+}) {
+  const { ref, hasBeenVisible } = useLazyLoad();
   const store = useStore<RootState>();
   const { userId, widgetApiPromise } = useLoggedIn();
-
   const [whiteboardManager, setWhiteboardManager] =
     useState<WhiteboardManager>();
 
   useEffect(() => {
+    if (!hasBeenVisible) return;
     const manager = createWhiteboardManager(store, widgetApiPromise, true);
     manager.selectActiveWhiteboardInstance(whiteboard, userId);
     setWhiteboardManager(manager);
     return () => {
       manager.clear();
+      setWhiteboardManager(undefined);
     };
-  }, [store, userId, widgetApiPromise, whiteboard]);
+  }, [hasBeenVisible, store, userId, widgetApiPromise, whiteboard]);
 
   return (
-    <>
+    <div ref={ref} style={{ width: '100%', height: '100%' }}>
       {whiteboardManager ? (
         <WhiteboardManagerProvider whiteboardManager={whiteboardManager}>
           <BoardSlidePreview />
@@ -64,9 +98,9 @@ export const BoardPreview: React.FC<BoardPreviewProps> = ({ whiteboard }) => {
       ) : (
         <SlideSkeleton />
       )}
-    </>
+    </div>
   );
-};
+}
 
 export function BoardSlidePreview() {
   const slideIds = useActiveWhiteboardInstanceSlideIds();

--- a/src/components/Dashboard/boardPreviewCache.ts
+++ b/src/components/Dashboard/boardPreviewCache.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * NeoBoard Standalone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * NeoBoard Standalone is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with NeoBoard Standalone. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const CACHE_NAME = 'neoboard-board-previews-v1';
+
+export async function savePreviewSvg(
+  roomId: string,
+  svgHtml: string,
+): Promise<void> {
+  if (!('caches' in window)) return;
+  const cache = await caches.open(CACHE_NAME);
+  await cache.put(
+    `/board-preview/${roomId}`,
+    new Response(svgHtml, { headers: { 'Content-Type': 'image/svg+xml' } }),
+  );
+}
+
+export async function getPreviewSvg(roomId: string): Promise<string | null> {
+  if (!('caches' in window)) return null;
+  const cache = await caches.open(CACHE_NAME);
+  const response = await cache.match(`/board-preview/${roomId}`);
+  return response ? response.text() : null;
+}

--- a/src/components/Dashboard/useLazyLoad.ts
+++ b/src/components/Dashboard/useLazyLoad.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Nordeck IT + Consulting GmbH
+ *
+ * NeoBoard Standalone is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * NeoBoard Standalone is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with NeoBoard Standalone. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { RefCallback, useCallback, useRef, useState } from 'react';
+
+export function useLazyLoad(rootMargin = '100px'): {
+  ref: RefCallback<HTMLDivElement>;
+  hasBeenVisible: boolean;
+} {
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+  const hasBeenVisibleRef = useRef(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const ref: RefCallback<HTMLDivElement> = useCallback(
+    (node) => {
+      if (!node) {
+        observerRef.current?.disconnect();
+        observerRef.current = null;
+        return;
+      }
+      if (hasBeenVisibleRef.current) return;
+      observerRef.current = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            hasBeenVisibleRef.current = true;
+            setHasBeenVisible(true);
+            observerRef.current?.disconnect();
+          }
+        },
+        { rootMargin },
+      );
+      observerRef.current.observe(node);
+    },
+    [rootMargin],
+  );
+
+  return { ref, hasBeenVisible };
+}


### PR DESCRIPTION
On navigation away from a board, capture the live SVG element and store it in the Cache API (no size limit, browser-managed eviction). On the dashboard, boards with a cached preview render as a static <img> with zero WhiteboardManager/Y.Doc overhead. Boards without a cache entry are lazy-loaded via IntersectionObserver so WhiteboardManagers are only created for tiles that are visible in the viewport.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
