### PR TITLE
perf(dashboard): replace O(N×M) loops in whiteboard selector with indexed lookups

### DIFF
--- a/.changeset/eager-pens-add.md
+++ b/.changeset/eager-pens-add.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-standalone': patch
+---
+
+Replace O(N×M) loops in whiteboard selector with indexed lookups

--- a/src/store/api/selectors/selectWhiteboards.ts
+++ b/src/store/api/selectors/selectWhiteboards.ts
@@ -98,6 +98,31 @@ export function makeSelectWhiteboards(
        */
       const seenRooms = new Set<string>();
 
+      // Pre-index the latest session event per room for this user (O(M) pre-pass)
+      const stateKey = matrixRtcMode ? `_${userId}_${deviceId}` : userId;
+      const latestSessionByRoom = Object.values(
+        whiteboardSessionsEvents,
+      ).reduce<Record<string, StateEvent<WhiteboardSessionsEvent>>>(
+        (acc, ev) => {
+          if (
+            ev.state_key === stateKey &&
+            (acc[ev.room_id] === undefined ||
+              acc[ev.room_id].origin_server_ts < ev.origin_server_ts)
+          ) {
+            acc[ev.room_id] = ev;
+          }
+          return acc;
+        },
+        {},
+      );
+
+      // Pre-index rooms where the current user is a member (O(M) pre-pass)
+      const memberRooms = new Set(
+        Object.values(roomMemberEvents)
+          .filter((e) => e?.state_key === userId)
+          .map((e) => e!.room_id),
+      );
+
       const boards: WhiteboardEntry[] = whiteboards.flatMap((whiteboard) => {
         const { room_id } = whiteboard;
 
@@ -109,38 +134,16 @@ export function makeSelectWhiteboards(
 
         const roomName = roomNameEvents[room_id]?.content.name;
 
-        let latestOwnWhiteboardSessionsEvent:
-          | StateEvent<WhiteboardSessionsEvent>
-          | undefined = undefined;
-
-        // Find latest whiteboardSessions for the whiteboard room and the current user
-        const stateKey = matrixRtcMode ? `_${userId}_${deviceId}` : userId;
-        Object.values(whiteboardSessionsEvents).forEach(
-          (whiteboardSessionsEvent) => {
-            if (
-              whiteboardSessionsEvent.room_id === whiteboard.room_id &&
-              whiteboardSessionsEvent.state_key === stateKey &&
-              (latestOwnWhiteboardSessionsEvent === undefined ||
-                latestOwnWhiteboardSessionsEvent.origin_server_ts <
-                  whiteboardSessionsEvent.origin_server_ts)
-            ) {
-              latestOwnWhiteboardSessionsEvent = whiteboardSessionsEvent;
-            }
-          },
-        );
-
         if (
           roomName &&
           // select rooms where user is a member (invited or joined, filters out leave membership)
-          Object.values(roomMemberEvents).some(
-            (e) => e && e.room_id === room_id && e.state_key === userId,
-          )
+          memberRooms.has(room_id)
         ) {
           return [
             {
               roomName,
               whiteboard,
-              whiteboardSessions: latestOwnWhiteboardSessionsEvent,
+              whiteboardSessions: latestSessionByRoom[room_id],
               powerLevels: powerLevelsEvents[room_id],
               roomCreateEvent: roomCreateEvents[room_id],
               preview: undefined,


### PR DESCRIPTION
makeSelectWhiteboards contained two nested linear scans that ran on every Redux state change: finding the latest session event per room required iterating all session events for every board, and checking membership required scanning all room member events for every board.

Replace both inner loops with O(M) pre-pass reductions that build a session-by-room map and a member-room Set before the whiteboard loop. Each per-board lookup is now O(1), reducing overall complexity from O(N×M) to O(N+M).

This should noticeably improve the startup of the dashboard for users with many boards or rooms in general.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
