### PR TITLE
fix(dashboard): add timeout and guaranteed cleanup to board creation poll

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -47,27 +47,35 @@ export function Dashboard() {
       },
     });
 
-    // create a promise that will be resolved when whiteboard data is in store
-    let promiseResolve: (value: unknown) => void;
-    const promise = new Promise((resolve) => {
-      promiseResolve = resolve;
-    });
-
     const selectWhiteboard = makeSelectWhiteboard(roomId);
-    const unsubscribe = store.subscribe(() => {
-      const state = store.getState();
 
-      const whiteboard = selectWhiteboard(state);
-      if (whiteboard) {
-        promiseResolve(undefined);
+    // Wait for the whiteboard state event to arrive in the store, with a
+    // timeout so a network failure doesn't leave the UI hung indefinitely.
+    let unsubscribe: (() => void) | undefined;
+    const whiteboardReady = new Promise<void>((resolve, reject) => {
+      // Check immediately in case the event already arrived
+      if (selectWhiteboard(store.getState())) {
+        resolve();
+        return;
       }
-    });
+
+      unsubscribe = store.subscribe(() => {
+        if (selectWhiteboard(store.getState())) resolve();
+      });
+
+      setTimeout(
+        () =>
+          reject(
+            new Error(t('dashboard.createTimeout', 'Board creation timed out')),
+          ),
+        30_000,
+      );
+    }).finally(() => unsubscribe?.());
 
     // create a whiteboard in the room
     await createWhiteboard(standaloneClient, roomId);
 
-    await promise;
-    unsubscribe();
+    await whiteboardReady;
 
     navigate(`/board/${roomId}`);
   }, [standaloneClient, t, navigate, store]);

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -35,6 +35,7 @@
     "createBoardTile": {
       "createBoard": "Neues Board erstellen"
     },
+    "createTimeout": "Zeitüberschreitung bei der Board-Erstellung",
     "sortBy": {
       "alphabetical": "Alphabetisch",
       "button": "Sortieren nach:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -35,6 +35,7 @@
     "createBoardTile": {
       "createBoard": "Create a new board"
     },
+    "createTimeout": "Board creation timed out",
     "sortBy": {
       "alphabetical": "Alphabetical",
       "button": "Sort by:",


### PR DESCRIPTION
After creating a room, the handler polled the Redux store via store.subscribe() waiting for the whiteboard state event. If the event never arrived due to a network error, the subscription lived forever and the UI was stuck with no error shown.

Replace with a Promise that resolves on the first matching store update, rejects after 30 seconds with a user-visible error, and always calls unsubscribe() via finally(). Also add an immediate check before subscribing to handle the case where the event already arrived.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
