### PR TITLE
fix(standalone): replace roomId-change effect in Title with inline guard

### DIFF
--- a/.changeset/spotty-deserts-love.md
+++ b/.changeset/spotty-deserts-love.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-standalone': patch
+---
+
+Replace roomId-change effect in Title with inline guard

--- a/src/components/Header/Title.tsx
+++ b/src/components/Header/Title.tsx
@@ -17,7 +17,7 @@
  */
 
 import { styled, Tooltip } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDashboardList } from '../Dashboard/useDashboardList';
 import { RenameDialog } from '../RenameDialog';
@@ -58,16 +58,18 @@ type TitleProps = {
 export function Title({ title, roomId }: TitleProps) {
   const { t } = useTranslation();
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [prevRoomId, setPrevRoomId] = useState(roomId);
+  if (prevRoomId !== roomId) {
+    setPrevRoomId(roomId);
+    setRenameDialogOpen(false);
+  }
+
   const dashboardList = useDashboardList();
   const roomItem = useMemo(
     () => dashboardList.find((item) => item.roomId === roomId),
     [dashboardList, roomId],
   );
   const canEditName = !!roomItem?.permissions.canChangeName;
-
-  useEffect(() => {
-    setRenameDialogOpen(false);
-  }, [roomId]);
 
   const handleOpenRenameDialog = useCallback(
     () => setRenameDialogOpen(true),


### PR DESCRIPTION
useEffect(() => { setRenameDialogOpen(false); }, [roomId]) caused React to commit the stale open state first, then fire the effect and re-render with the corrected state. Replace with an inline prev-prop comparison so the reset happens during the render that processes the roomId change.

BoardPreview and LanguageDialog were reviewed; their effects perform real side effects (manager setup/cleanup and localStorage+i18n) so no change.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
