### PR TITLE
perf(standalone): stabilize RoomIdProvider context value with useMemo

### DIFF
--- a/.changeset/new-hairs-brake.md
+++ b/.changeset/new-hairs-brake.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-standalone': patch
+---
+
+Stabilize RoomIdProvider context value with useMemo

--- a/src/components/RoomIdProvider/RoomIdProvider.tsx
+++ b/src/components/RoomIdProvider/RoomIdProvider.tsx
@@ -16,7 +16,7 @@
  * along with NeoBoard Standalone. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { createContext, PropsWithChildren } from 'react';
+import { createContext, PropsWithChildren, useMemo } from 'react';
 import { useParams } from 'react-router';
 
 type RoomIdContextType = {
@@ -29,10 +29,9 @@ export const RoomIdContext = createContext<RoomIdContextType | undefined>(
 
 export function RoomIdProvider({ children }: PropsWithChildren<{}>) {
   const { roomId } = useParams();
+  const ctx = useMemo(() => ({ roomId }), [roomId]);
 
   return (
-    <RoomIdContext.Provider value={{ roomId }}>
-      {children}
-    </RoomIdContext.Provider>
+    <RoomIdContext.Provider value={ctx}>{children}</RoomIdContext.Provider>
   );
 }


### PR DESCRIPTION
The inline { roomId } object was recreated on every render, causing all consumers of RoomIdContext to re-render even when the roomId hadn't changed. Wrap in useMemo so consumers only re-render on actual route changes.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
