### PR TITLE
perf(standalone): switch lodash imports to per-function entry points

### DIFF
--- a/.changeset/shaggy-onions-dig.md
+++ b/.changeset/shaggy-onions-dig.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/matrix-neoboard-standalone': patch
+---
+
+Switch lodash imports to per-function entry points

--- a/src/components/BoardView/BoardViewWrapper.tsx
+++ b/src/components/BoardView/BoardViewWrapper.tsx
@@ -16,7 +16,7 @@
  * along with NeoBoard Standalone. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useMemo } from 'react';
 import { makeSelectWhiteboard, useAppSelector } from '../../store';
 import { useOpenedRoomId } from '../RoomIdProvider';

--- a/src/components/Dashboard/BoardPreview.tsx
+++ b/src/components/Dashboard/BoardPreview.tsx
@@ -28,7 +28,7 @@ import {
   WhiteboardManager,
   WhiteboardManagerProvider,
 } from '@nordeck/matrix-neoboard-react-sdk';
-import { first } from 'lodash';
+import first from 'lodash/first';
 import React, { useEffect, useState } from 'react';
 import { useStore } from 'react-redux';
 import { useLoggedIn } from '../../state';

--- a/src/components/Dashboard/useDashboardList.ts
+++ b/src/components/Dashboard/useDashboardList.ts
@@ -18,7 +18,7 @@
 
 import { StateEvent } from '@matrix-widget-toolkit/api';
 import { Whiteboard } from '@nordeck/matrix-neoboard-react-sdk';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatTimeAgo } from '../../lib';
 import {

--- a/src/components/Header/InvitesDialog.tsx
+++ b/src/components/Header/InvitesDialog.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Dialog, DialogContent, DialogTitle, List } from '@mui/material';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useEffect, useId, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoggedIn } from '../../state';

--- a/src/components/Header/InvitesMenu.tsx
+++ b/src/components/Header/InvitesMenu.tsx
@@ -18,7 +18,7 @@
 
 import Notifications from '@mui/icons-material/Notifications';
 import { Badge, IconButton, Tooltip } from '@mui/material';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoggedIn } from '../../state';

--- a/src/components/Header/ShareMenuModal.tsx
+++ b/src/components/Header/ShareMenuModal.tsx
@@ -31,7 +31,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import {
   FocusEvent,
   MouseEvent,

--- a/src/store/api/whiteboardApi.ts
+++ b/src/store/api/whiteboardApi.ts
@@ -24,7 +24,8 @@ import {
   Whiteboard,
 } from '@nordeck/matrix-neoboard-react-sdk';
 import { createEntityAdapter, EntityState } from '@reduxjs/toolkit';
-import { isEqual, isError } from 'lodash';
+import isEqual from 'lodash/isEqual';
+import isError from 'lodash/isError';
 import { Symbols } from 'matrix-widget-api';
 import { bufferTime, filter } from 'rxjs';
 import { RootState, ThunkExtraArgument } from '../store';

--- a/src/toolkit/standalone/client/MatrixStandaloneClient.ts
+++ b/src/toolkit/standalone/client/MatrixStandaloneClient.ts
@@ -26,7 +26,7 @@ import {
   isValidCreateEventSchema,
   isValidPowerLevelStateEvent,
 } from '@matrix-widget-toolkit/api';
-import { last } from 'lodash';
+import last from 'lodash/last';
 import {
   ClientEvent,
   Direction,


### PR DESCRIPTION
Importing named functions from 'lodash' pulls the entire ~70 kb bundle into the chunk. Switch all 8 usages to their individual entry points (lodash/isEqual, lodash/isError, lodash/first, lodash/last) so bundlers can tree-shake to only the ~2 kb needed per function.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
