### PR TITLE
latest tag only applies on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,6 @@ jobs:
             org.opencontainers.image.description=Standalone version of NeoBoard: A whiteboard widget for Matrix
             org.opencontainers.image.vendor=Nordeck IT + Consulting GmbH
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=
             type=raw,value=${{ env.ARGOCD_TAG }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,6 +38,7 @@ jobs:
             org.opencontainers.image.vendor=Nordeck IT + Consulting GmbH
           tags: |
             type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Generate Dockerfile
         env:


### PR DESCRIPTION
Removes the `latest` tag from every build on push to main and correctly applies it only on new releases.