### PR TITLE
fix(chart): Make openDesk kyverno linting happy

### DIFF
--- a/charts/matrix-neoboard-standalone/Chart.yaml
+++ b/charts/matrix-neoboard-standalone/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: matrix-neoboard-standalone
 description: Standalone version of NeoBoard (https://github.com/nordeck/matrix-neoboard) - A collaborative whiteboard widget for Element, based on Matrix.
 type: application
-version: 0.0.9
+version: 0.0.10
 # renovate: image=ghcr.io/nordeck/matrix-neoboard-standalone
 appVersion: '0.0.0'
 home: https://neoboard.io

--- a/charts/matrix-neoboard-standalone/templates/_helpers.tpl
+++ b/charts/matrix-neoboard-standalone/templates/_helpers.tpl
@@ -55,7 +55,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "app.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccountName -}}
+    {{ .Values.serviceAccountName }}
+{{- else if .Values.serviceAccount.create -}}
     {{ default (include "app.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}

--- a/charts/matrix-neoboard-standalone/templates/deployment.yaml
+++ b/charts/matrix-neoboard-standalone/templates/deployment.yaml
@@ -13,10 +13,10 @@ spec:
       {{- include "app.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
       annotations:
-        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
     spec:
@@ -24,7 +24,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -37,14 +38,14 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/matrix-neoboard-standalone/templates/hpa.yaml
+++ b/charts/matrix-neoboard-standalone/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "app.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/matrix-neoboard-standalone/templates/serviceaccount.yaml
+++ b/charts/matrix-neoboard-standalone/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serviceAccount.create (not .Values.serviceAccountName) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+{{ include "app.labels" . | indent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/matrix-neoboard-standalone/templates/tests/test-connection.yaml
+++ b/charts/matrix-neoboard-standalone/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: busybox:1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
       command: ['wget']
       args:  ['{{ include "app.fullname" . }}:8080', '-O', '/dev/null']
       securityContext:
@@ -21,4 +21,3 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
   restartPolicy: Never
-

--- a/charts/matrix-neoboard-standalone/values.yaml
+++ b/charts/matrix-neoboard-standalone/values.yaml
@@ -14,16 +14,43 @@ imagePullSecrets:
 nameOverride: ''
 fullnameOverride: ''
 
+# Deprecated: use serviceAccount.create=false and serviceAccount.name instead.
+serviceAccountName: ''
+
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ''
 
+# This satisfies the second branch of openDesk's `disallow-default-serviceaccount`
+# policy, which passes a pod that either does not use `default` OR mounts no token:
+# https://gitlab.opencode.de/bmi/opendesk/deployment/opendesk/-/blob/main/.kyverno/policies/disallow-default-serviceaccount.yaml
+automountServiceAccountToken: false
+
 podAnnotations: {}
+
+# Satisfies openDesk's `require-health-and-liveness-check` which
+# asserts `periodSeconds > 0` on the rendered manifest:
+# https://gitlab.opencode.de/bmi/opendesk/deployment/opendesk/-/blob/main/.kyverno/policies/require-health-and-liveness-check.yaml
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
 
 podSecurityContext:
   {}


### PR DESCRIPTION
When integrating the NeoBoard app into the openDesk deployment charts, we got the following linting issues raised:

Aggregated Failed Test Cases : 
│ 1  │ disallow-default-serviceaccount   │ disallow-default-serviceAccountName │  Fail   │ Want pass, got fail │
│ 2  │ require-health-and-liveness-check │ require-health-and-liveness-check   │ Fail   │ Want pass, got fail │
│ 3  │ require-containersecuritycontext  │ require-empty-seLinuxOptions        │  Fail   │ Want pass, got fail │
Error: 3 tests failed

This PR addresses the first two issues, the third will be done under the oD charts.

**Note**: This PR was assisted by an LLM and curated by me.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
